### PR TITLE
Add argument parsing to enable a "today" flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,23 @@ This is a script for syncing crosswords to a reMarkable device. It doesn't need 
 4. To run the executable manually, while in the `remarkable-crossword-dl/` folder, enter `./syncCrosswords.py <start_date> <end_date>`. The dates should be in ISO format (YYYY-MM-DD), and if not provided have defaults. `end_date` defaults to tomorrow, since NYT crosswords are published the evening before, and `start_date` defaults to the last undownloaded puzzle on your reMarkable cloud, with a max of 10 days ago.
 5. You can also schedule it with your choice of script scheduler. An example plist for use with launchd is included in this project.
 
+## Usage
+
+```
+$ ./syncCrosswords.py --help
+usage: syncCrosswords.py [-h] [-t] [start] [end]
+
+Syncs a copy of the New York Times Crossword to your Remarkable
+
+positional arguments:
+  start        Start Date in ISO format (YYYY-MM-DD)
+  end          End Date in ISO format (YYYY-MM-DD)
+
+optional arguments:
+  -h, --help   show this help message and exit
+  -t, --today  Just get today's crossword. NOTE: Will ignore start/end arguments.
+```
+
 ## Sources
 [HTTP requests for NYT Crossword](https://www.reddit.com/r/crossword/comments/dqtnca/my_automatic_nyt_crossword_downloading_script/)
 

--- a/syncCrosswords.py
+++ b/syncCrosswords.py
@@ -1,10 +1,21 @@
 #!/usr/bin/env python3
 
+import argparse
 import nyt2rM
 import datetime
 import sys
 
-dateStart,dateEnd = None,None
-if len(sys.argv) > 1: dateStart = datetime.date.fromisoformat(sys.argv[1])
-if len(sys.argv) > 2: dateEnd = datetime.date.fromisoformat(sys.argv[2])
+parser = argparse.ArgumentParser(description="Syncs a copy of the New York Times Crossword to your Remarkable")
+parser.add_argument("start", help="Start Date in ISO format (YYYY-MM-DD)", default=None, nargs='?')
+parser.add_argument("end", help="End Date in ISO format (YYYY-MM-DD)", default=None, nargs='?')
+parser.add_argument("-t", "--today", help="Just get today's crossword. NOTE: Will ignore start/end arguments.", action='store_true')
+args = parser.parse_args()
+
+if not args.today:
+  dateStart = datetime.date.fromisoformat(args.start)
+  dateEnd = datetime.date.fromisoformat(args.end)
+else:
+  dateStart = datetime.date.today()
+  dateEnd = None
+
 nyt2rM.downloadNytCrosswords(dateStart,dateEnd)


### PR DESCRIPTION
I just used argparse to:
1. Add some help output on how to call the script
2. Add a `--today` or `-t` flag so I dont really need to do anything fancy to generate dates, etc